### PR TITLE
Replace 'round()' with 'np.floor()' and 'np.ceil()'

### DIFF
--- a/calculate_team.py
+++ b/calculate_team.py
@@ -431,12 +431,10 @@ def p75(lis, exception=0.0, cycles=False):
         # If the cycles specifcation is true, it takes the lower half of
         # the list, which are the faster cycle times.
         if cycles is True:
-            # math.ceil rounds the float up to be an int, does this to
-            # avoid errors when lis only has one item.
+            # 'math.ceil()' rounds the float up to be an int.
             upper_half = lis[:math.ceil(len(lis) / 2)]
         else:
-            # math.floor rounds the float down to be an int, does this
-            # to avoid errors when lis only has one item.
+            # 'math.floor()' rounds the float down to be an int.
             upper_half = lis[-math.floor(len(lis) / 2):]
         return sum(upper_half) / len(upper_half)
 


### PR DESCRIPTION
'round()' rounds 0.5 down to 0, so when only one item is in the list, it would retrieve a blank list when we want the one item to be returned.